### PR TITLE
Blog - 301 redirect

### DIFF
--- a/nginx-config.md
+++ b/nginx-config.md
@@ -30,6 +30,7 @@
       rewrite ^/(([^/]+/)*)index\.html?$ https://keenethics.com/$1 redirect;
       rewrite ^/(([^/]+/)*)index\.php?$ https://keenethics.com/$1 redirect;
       rewrite ^/(([^/]+/)*)default\.html?$ https://keenethics.com/$1 redirect;
+      rewrite ^/post?name=(.*)$ https://keenethics.com/blog/$1 permanent;
       rewrite ^/(.*)/$ /$1 permanent;
     }
   }


### PR DESCRIPTION
@epaminond It was necessary to make a redirect from `https://keenethics.com/post?name=${postTitle}` to `https://keenethics.com/blog/${postTitle}` for blog news. This line should do it. Could you check it, please?